### PR TITLE
fix: update generate-changelog workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -72,7 +72,7 @@ labels:
     matcher:
       body: "(\\n|.)*/bug(\\n|.)*"
 
-  - label: "type: testing 🤖"
+  - label: "type: testing 🔎"
     sync: true
     matcher:
       body: "(\\n|.)*/test(\\n|.)*"

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -34,9 +34,17 @@ jobs:
           contents: ${{ steps.changelog.outputs.changelog }}
           write-mode: overwrite
 
-      - name: Commit and push CHANGELOG.md ↗️
-        uses: EndBug/add-and-commit@v7
+      - name: Create Pull Request 🐙
+        uses: peter-evans/create-pull-request@v4
         with:
-          add: CHANGELOG.md
-          message: "chore: Update CHANGELOG.md [skip ci]"
-          branch: main
+          commit_message: "docs: update CHANGELOG.md for release [skip ci]"
+          branch: automated-pr/update-changelog
+          delete_branch: true
+          branch-suffix: timestamp
+          title: "🐖 - chore: update CHANGELOG.md for new release [automated]"
+          body: |
+            Update CHANGELOG.md after new release 
+            Automated changes by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action
+            /1 /clear /docs
+          assignees: rolasotelo
+          labels: "automated 🤖"

--- a/.github/workflows/label-checker.yml
+++ b/.github/workflows/label-checker.yml
@@ -56,5 +56,5 @@ jobs:
       - uses: docker://agilepathway/pull-request-label-checker:latest
         with:
           one_of: |
-            type: fix 🩹,type: security 🔒,type: documentation 📝,type: infrastructure 🧱,type: feature ✨,type: hotfix 🚑,type: bug 🐛,type: testing 🤖,type: dx 👩🏼‍💻,type: ci/cd 👷🏾,type: improvement ⚡️,
+            type: fix 🩹,type: security 🔒,type: documentation 📝,type: infrastructure 🧱,type: feature ✨,type: hotfix 🚑,type: bug 🐛,type: testing 🔎,type: dx 👩🏼‍💻,type: ci/cd 👷🏾,type: improvement ⚡️,
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Next you can find a list of things you need to consider when using this template
 - Giphy generator workflow (by @iamhughes) will need GIPHY_TOKEN secret to be set at your repo, profile or organization level, in order to work.
 - Label commenter workflow (by @peaceiris) configuration is customized to be used inside @nantli and before you can use it outside of the organization you will need to update [label-commenter-config.yml](.github/label-commenter-config.yml) to your liking.
 - Generate changelog workflow (by @loopwerk) assumes the use of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
+- Multi labeler workflow (by @fuxingloh) configuration is also customized to be used inside @nantli and before you can use it outside of the organization you will need to update [labeler.yml](.github/labeler.yml) to your liking.
+- Label Checker workflow (by @agilepathway) configuration is also customized to be used inside @nantli and before you can use it outside of the organization you will need to update [labeler.yml](.github/workflow/label-checker.yml) to your liking.
 
 ### A quick introduction to Conventional Commits format
 


### PR DESCRIPTION
Now a PR is automatically created for CHANGELOG.md release changes
[create-pull-request](https://github.com/peter-evans/create-pull-request) is the new action being used.

/1 /ci /clear