### PR TITLE
fix: add base input and replace wrong inputs to changelog-generator configuration

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -37,9 +37,10 @@ jobs:
       - name: Create Pull Request 🐙
         uses: peter-evans/create-pull-request@v4
         with:
-          commit_message: "docs: update CHANGELOG.md for release [skip ci]"
+          commit-message: "docs: update CHANGELOG.md for release [skip ci]"
           branch: automated-pr/update-changelog
-          delete_branch: true
+          delete-branch: true
+          base: main
           branch-suffix: timestamp
           title: "🐖 - chore: update CHANGELOG.md for new release [automated]"
           body: |

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Next you can find a list of things you need to consider when using this template
 - Label commenter workflow (by @peaceiris) configuration is customized to be used inside @nantli and before you can use it outside of the organization you will need to update [label-commenter-config.yml](.github/label-commenter-config.yml) to your liking.
 - Generate changelog workflow (by @loopwerk) assumes the use of [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
 - Multi labeler workflow (by @fuxingloh) configuration is also customized to be used inside @nantli and before you can use it outside of the organization you will need to update [labeler.yml](.github/labeler.yml) to your liking.
-- Label Checker workflow (by @agilepathway) configuration is also customized to be used inside @nantli and before you can use it outside of the organization you will need to update [labeler.yml](.github/workflow/label-checker.yml) to your liking.
+- Label Checker workflow (by @agilepathway) configuration is also customized to be used inside @nantli and before you can use it outside of the organization you will need to update [label-checker.yml](.github/workflow/label-checker.yml) to your liking.
 
 ### A quick introduction to Conventional Commits format
 


### PR DESCRIPTION
Add base input to changelog-generator configuration and replace (incorrect inputs) 'commit_message', 'delete_branch' by 'commit-message', 'delete-branch'.

- [x] Share some love to the animals

/1 /ci /clear

/giphy pigs in mud